### PR TITLE
Fix extension configuration not returning correct type

### DIFF
--- a/src/main/java/org/concordion/ext/timing/TimerExtension.java
+++ b/src/main/java/org/concordion/ext/timing/TimerExtension.java
@@ -37,7 +37,7 @@ public class TimerExtension implements ConcordionExtension {
      * @param newIconPath is the path to the toggle icon image you wish to use.
      * @return Returns the extension with the changed toggle icon.
      */
-    public ConcordionExtension withIcon(String newIconPath) {
+    public TimerExtension withIcon(String newIconPath) {
         toggleIconPath = newIconPath;
         return this;
     }
@@ -49,7 +49,7 @@ public class TimerExtension implements ConcordionExtension {
      *
      * @param timeFormat an implementation of a TimeFormatter
      */
-    public ConcordionExtension withTimeFormatter(TimeFormatter timeFormat){
+    public TimerExtension withTimeFormatter(TimeFormatter timeFormat){
         this.timeFormatter = timeFormat;
         return this;
     }


### PR DESCRIPTION
Missed this commit in the past pull request, fixes not being able to chain the configuration
methods without type casting.
